### PR TITLE
avoid unstaking and system contract ops mishaps

### DIFF
--- a/contracts/eos/BancorConverter/BancorConverter.abi
+++ b/contracts/eos/BancorConverter/BancorConverter.abi
@@ -1,5 +1,5 @@
 {
-    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT Thu Jan 24 11:36:39 2019",
+    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT Mon Feb 18 10:13:52 2019",
     "version": "eosio::abi/1.0",
     "structs": [
         {

--- a/contracts/eos/BancorConverter/BancorConverter.cpp
+++ b/contracts/eos/BancorConverter/BancorConverter.cpp
@@ -342,7 +342,7 @@ float BancorConverter::stof(const char* s) {
 
 void BancorConverter::transfer(name from, name to, asset quantity, string memo) {
     // avoid unstaking and system contract ops mishaps
-    if (from == _self || from == "eosio"_n || from == "eosio.stake"_n) {
+    if (from == _self || from == "eosio.ram"_n || from == "eosio.stake"_n) {
         // TODO: prevent withdrawal of reserve balances without depositing relay tokens
         return;
     }

--- a/contracts/eos/BancorConverter/BancorConverter.cpp
+++ b/contracts/eos/BancorConverter/BancorConverter.cpp
@@ -341,8 +341,9 @@ float BancorConverter::stof(const char* s) {
 };
 
 void BancorConverter::transfer(name from, name to, asset quantity, string memo) {
-    if (from == _self) {
-        // TODO: prevent withdrawal of funds
+    // avoid unstaking and system contract ops mishaps
+    if (from == _self || from == "eosio"_n || from == "eosio.stake"_n) {
+        // TODO: prevent withdrawal of reserve balances without depositing relay tokens
         return;
     }
 

--- a/contracts/eos/BancorNetwork/BancorNetwork.abi
+++ b/contracts/eos/BancorNetwork/BancorNetwork.abi
@@ -1,5 +1,5 @@
 {
-    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT Thu Jan 24 11:36:35 2019",
+    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT Mon Feb 18 10:13:47 2019",
     "version": "eosio::abi/1.0",
     "structs": [
         {

--- a/contracts/eos/BancorNetwork/BancorNetwork.cpp
+++ b/contracts/eos/BancorNetwork/BancorNetwork.cpp
@@ -8,7 +8,8 @@ ACTION BancorNetwork::init() {
 }
 
 void BancorNetwork::transfer(name from, name to, asset quantity, string memo) {
-    if (to != _self)
+    // avoid unstaking and system contract ops mishaps
+    if (to != _self || from == "eosio"_n || from == "eosio.stake"_n)
         return;
  
     // auto a = extended_asset(, code);

--- a/contracts/eos/BancorNetwork/BancorNetwork.cpp
+++ b/contracts/eos/BancorNetwork/BancorNetwork.cpp
@@ -9,7 +9,7 @@ ACTION BancorNetwork::init() {
 
 void BancorNetwork::transfer(name from, name to, asset quantity, string memo) {
     // avoid unstaking and system contract ops mishaps
-    if (to != _self || from == "eosio"_n || from == "eosio.stake"_n)
+    if (to != _self || from == "eosio.ram"_n || from == "eosio.stake"_n)
         return;
  
     // auto a = extended_asset(, code);

--- a/contracts/eos/BancorX/BancorX.abi
+++ b/contracts/eos/BancorX/BancorX.abi
@@ -1,5 +1,5 @@
 {
-    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT Thu Jan 24 11:36:32 2019",
+    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT Mon Feb 18 10:13:45 2019",
     "version": "eosio::abi/1.0",
     "structs": [
         {

--- a/contracts/eos/Token/Token.abi
+++ b/contracts/eos/Token/Token.abi
@@ -1,5 +1,5 @@
 {
-    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT Thu Jan 24 11:36:28 2019",
+    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT Mon Feb 18 10:13:40 2019",
     "version": "eosio::abi/1.0",
     "structs": [
         {

--- a/contracts/eos/XTransferRerouter/XTransferRerouter.abi
+++ b/contracts/eos/XTransferRerouter/XTransferRerouter.abi
@@ -1,5 +1,5 @@
 {
-    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT Thu Jan 24 11:36:42 2019",
+    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT Mon Feb 18 10:13:55 2019",
     "version": "eosio::abi/1.0",
     "structs": [
         {


### PR DESCRIPTION
This pull request fixes a bug which prevents our converter/network contract to unstake cpu/net or sell ram.