### PR TITLE
Number loss

### DIFF
--- a/contracts/eos/MultiConverter/MultiConverter.cpp
+++ b/contracts/eos/MultiConverter/MultiConverter.cpp
@@ -261,19 +261,17 @@ ACTION MultiConverter::fund(name sender, asset quantity) {
     reserves reserves_table(get_self(), quantity.symbol.code().raw());
     
     double total_ratio = 0.0;
-    double smart_amount = quantity.amount / pow(10, quantity.symbol.precision());
-    double current_smart_supply = supply.amount / pow(10, quantity.symbol.precision());
+    double smart_amount = quantity.amount;
+    double current_smart_supply = supply.amount;
+    double percent = smart_amount / current_smart_supply;
 
     for (auto& reserve : reserves_table) {
         total_ratio += reserve.ratio;
-        double balance = reserve.balance.amount / pow(10, reserve.balance.symbol.precision());
-        double amount = (smart_amount / current_smart_supply) * balance;
-        uint64_t liq_amount = amount * pow(10, reserve.balance.symbol.precision());
-        asset liq = asset(liq_amount, reserve.balance.symbol);
+        asset liq = asset(reserve.balance.amount * percent, reserve.balance.symbol);
         
+        check(liq.amount > 0, "fund amount too small");
         mod_account_balance(sender, quantity.symbol.code(), -liq);
         mod_reserve_balance(quantity.symbol, liq);
-        check(liq_amount > 0, "fund amount too small");
     }
     check(total_ratio == MAX_RATIO, "total ratio must add up to 100%");
     action( // issue new smart tokens to the issuer

--- a/test/eos/multiConvert.test.js
+++ b/test/eos/multiConvert.test.js
@@ -249,6 +249,12 @@ describe('Test: multiConverter', () => {
             await expectNoError(
                 fund(user1, '1000.00000000 BNTEOS')
             )
+
+            eosTemp = await getAccount(user1, "BNTEOS", "EOS");
+            bntTemp = await getAccount(user1, "BNTEOS", "BNT");
+            assert.equal(eosTemp.rows.length, 0, "was expecting to have no bank balance")
+            assert.equal(bntTemp.rows.length, 0, "was expecting to have no bank balance")
+
             await expectError( // last fund cleared the accounts row
                 fund(user1, '10000.00000000 BNTEOS'),
                 "cannot withdraw non-existant deposit"
@@ -548,23 +554,14 @@ describe('Test: multiConverter', () => {
             assert.equal(balance, '10.00000000', 'BNT account balance invalid')
         })
 
-        it("funding: should decrease a users account balance while funding small amounts", async() => {
-
-            await expectNoError(
-                fund(user1, '0.00009000 BNTEOS')
+        it("funding: should reject a fund amount too small to award", async() => {
+            await expectError(
+                fund(user1, '0.00009000 BNTEOS'),
+                "fund amount too small"
             )
-
-            result = await getAccount(user1, 'BNTEOS', 'EOS')
-            var balance = result.rows[0].quantity.split(' ')[0]
-            assert.notEqual(balance, '10.0000', 'EOS account balance was meant to decrease')
-
-            result = await getAccount(user1, 'BNTEOS', 'BNT')
-            var balance = result.rows[0].quantity.split(' ')[0]
-            assert.notEqual(balance, '10.00000000', 'BNT account balance was meant to decrease')
-
         })
 
-        it.skip("fund cost should be relative to fund amount", async() => {
+        it("fund cost should cost as expected", async() => {
 
             await expectNoError(
                 fund(user1, '1.50000000 BNTEOS')
@@ -580,20 +577,5 @@ describe('Test: multiConverter', () => {
 
         })
 
-        it.skip("fund cost should be relative to fund amount", async() => {
-
-            await expectNoError(
-                fund(user1, '2.50000000 BNTEOS')
-            )
-
-            result = await getAccount(user1, 'BNTEOS', 'EOS')
-            var balance = result.rows[0].quantity
-            assert.notEqual(balance, "9.0000 EOS", 'EOS balance came back static')
-            
-            result = await getAccount(user1, 'BNTEOS', 'BNT')
-            var balance = result.rows[0].quantity
-            assert.notEqual(balance, "9.00000000 BNT", 'BNT balance came back static')
-
-        })
     })
 })

--- a/test/eos/multiConvert.test.js
+++ b/test/eos/multiConvert.test.js
@@ -561,19 +561,37 @@ describe('Test: multiConverter', () => {
             )
         })
 
-        it("fund cost should cost as expected", async() => {
+        it("funding: charges as expected", async() => {
+
+
+            let [userEosBefore, userBntBefore] = await Promise.all([getAccount(user1, 'BNTEOS', 'EOS'), getAccount(user1, 'BNTEOS', 'BNT')])
 
             await expectNoError(
-                fund(user1, '1.50000000 BNTEOS')
+                fund(user1, '148.50000000 BNTEOS')
             )
 
             result = await getAccount(user1, 'BNTEOS', 'EOS')
-            var balance = result.rows[0].quantity
-            assert.notEqual(balance, "9.0000 EOS", 'EOS balance came back static')
+            var balance = result.rows[0].quantity.split(' ')[0]
+            assert.equal(balance, Number(userEosBefore.rows[0].quantity.split(' ')[0]) - 1.485, 'EOS balance invalid')
             
-            result = await getAccount(user1, 'BNTEOS', 'BNT')
-            var balance = result.rows[0].quantity
-            assert.notEqual(balance, "9.00000000 BNT", 'BNT balance came back static')
+            result = await getAccount(user1, 'BNTEOS', 'EOS')
+            var balance = result.rows[0].quantity.split(' ')[0]
+            assert.equal(balance, Number(userBntBefore.rows[0].quantity.split(' ')[0]) - 1.485, 'EOS balance invalid')
+
+
+            const [userEosBefore2, userBntBefore2] = await Promise.all([getAccount(user1, 'BNTEOS', 'EOS'), getAccount(user1, 'BNTEOS', 'BNT')])
+
+            await expectNoError(
+                fund(user1, '657.94500123 BNTEOS')
+            )
+
+            result = await getAccount(user1, 'BNTEOS', 'EOS')
+            var balance = result.rows[0].quantity.split(' ')[0]
+            assert.equal(balance, new Decimal(Number(userEosBefore2.rows[0].quantity.split(' ')[0])).minus(6.5794).toString(), 'EOS balance invalid')
+            
+            result = await getAccount(user1, 'BNTEOS', 'EOS')
+            var balance = result.rows[0].quantity.split(' ')[0]
+            assert.equal(balance, new Decimal(Number(userBntBefore2.rows[0].quantity.split(' ')[0])).minus(6.5794), 'EOS balance invalid')
 
         })
 

--- a/test/eos/multiConvert.test.js
+++ b/test/eos/multiConvert.test.js
@@ -572,11 +572,11 @@ describe('Test: multiConverter', () => {
 
             result = await getAccount(user1, 'BNTEOS', 'EOS')
             var balance = result.rows[0].quantity
-            assert.equal(balance, "9.0000 EOS", 'EOS balance came back static')
+            assert.notEqual(balance, "9.0000 EOS", 'EOS balance came back static')
             
             result = await getAccount(user1, 'BNTEOS', 'BNT')
             var balance = result.rows[0].quantity
-            assert.equal(balance, "9.00000000 BNT", 'BNT balance came back static')
+            assert.notEqual(balance, "9.00000000 BNT", 'BNT balance came back static')
 
         })
 
@@ -588,11 +588,11 @@ describe('Test: multiConverter', () => {
 
             result = await getAccount(user1, 'BNTEOS', 'EOS')
             var balance = result.rows[0].quantity
-            assert.equal(balance, "9.0000 EOS", 'EOS balance came back static')
+            assert.notEqual(balance, "9.0000 EOS", 'EOS balance came back static')
             
             result = await getAccount(user1, 'BNTEOS', 'BNT')
             var balance = result.rows[0].quantity
-            assert.equal(balance, "9.00000000 BNT", 'BNT balance came back static')
+            assert.notEqual(balance, "9.00000000 BNT", 'BNT balance came back static')
 
         })
     })


### PR DESCRIPTION
The fund action appears to be failing in these tests I wrote.
One can use the ::fund action for small enough quantities and not be charged in their contract managed account balance
They can also buy different amounts but be charged the same amount from the reserve. 

I believe there may be a math fault where uint64_t is being used too early, dropping any decimal values 
```uint64_t amount = (smart_amount * balance - 1) / current_smart_supply + 1;```