### PR TITLE
Multi converter default token precision

### DIFF
--- a/contracts/eos/MultiConverter/MultiConverter.abi
+++ b/contracts/eos/MultiConverter/MultiConverter.abi
@@ -76,10 +76,6 @@
                 {
                     "name": "initial_supply",
                     "type": "float64"
-                },
-                {
-                    "name": "maximum_supply",
-                    "type": "float64"
                 }
             ]
         },

--- a/contracts/eos/MultiConverter/MultiConverter.abi
+++ b/contracts/eos/MultiConverter/MultiConverter.abi
@@ -70,12 +70,16 @@
                     "type": "name"
                 },
                 {
+                    "name": "token_code",
+                    "type": "symbol_code"
+                },
+                {
                     "name": "initial_supply",
-                    "type": "asset"
+                    "type": "float64"
                 },
                 {
                     "name": "maximum_supply",
-                    "type": "asset"
+                    "type": "float64"
                 }
             ]
         },
@@ -228,7 +232,7 @@
             "base": "",
             "fields": [
                 {
-                    "name": "operational",
+                    "name": "active",
                     "type": "bool"
                 },
                 {

--- a/contracts/eos/MultiConverter/MultiConverter.cpp
+++ b/contracts/eos/MultiConverter/MultiConverter.cpp
@@ -294,10 +294,6 @@ void MultiConverter::liquidate(name sender, asset quantity) {
     settings settings_table(get_self(), get_self().value);
     const auto& st = settings_table.get("settings"_n.value, "settings do not exist");
     check(get_first_receiver() == st.multi_token, "bad origin for this transfer");
-
-    converters converters_table(get_self(), quantity.symbol.code().raw());
-    const auto& converter = converters_table.get(quantity.symbol.code().raw(), "converter does not exist");
-    check(converter.currency == quantity.symbol, "symbol mismatch");
     
     asset supply = get_supply(st.multi_token, quantity.symbol.code());
     reserves reserves_table(get_self(), quantity.symbol.code().raw());
@@ -647,7 +643,7 @@ void MultiConverter::on_transfer(name from, name to, asset quantity, string memo
     const auto& splitted_memo = split(memo, ";");
     if (splitted_memo[0] == "fund")
         mod_balances(from, quantity, symbol_code(splitted_memo[1]), get_first_receiver());
-    else if (splitted_memo[0] == "liquidate" && get_first_receiver() == st.multi_token)
+    else if (splitted_memo[0] == "liquidate")
         liquidate(from, quantity);
     
     else convert(from, quantity, memo, get_first_receiver()); 

--- a/contracts/eos/MultiConverter/MultiConverter.cpp
+++ b/contracts/eos/MultiConverter/MultiConverter.cpp
@@ -10,7 +10,7 @@
 
 ACTION MultiConverter::create(name owner, symbol_code token_code, double initial_supply) {
     require_auth(owner);
-    
+
     symbol token_symbol = symbol(token_code, DEFAULT_TOKEN_PRECISION);
     double maximum_supply = DEFAULT_MAX_SUPPLY;
 
@@ -639,9 +639,7 @@ void MultiConverter::on_transfer(name from, name to, asset quantity, string memo
         from == "eosio.ram"_n || from == "eosio.stake"_n || from == "eosio.rex"_n) return;
 
     check(quantity.is_valid() && quantity.amount > 0, "invalid quantity");
-    settings settings_table(get_self(), get_self().value);
-    const auto& st = settings_table.get("settings"_n.value, "settings do not exist");
-
+    
     const auto& splitted_memo = split(memo, ";");
     if (splitted_memo[0] == "fund")
         mod_balances(from, quantity, symbol_code(splitted_memo[1]), get_first_receiver());

--- a/contracts/eos/MultiConverter/MultiConverter.cpp
+++ b/contracts/eos/MultiConverter/MultiConverter.cpp
@@ -8,9 +8,11 @@
 #include "../Token/Token.hpp"
 #include "MultiConverter.hpp"
 
-ACTION MultiConverter::create(name owner, symbol_code token_code, double initial_supply, double maximum_supply) {
+ACTION MultiConverter::create(name owner, symbol_code token_code, double initial_supply) {
     require_auth(owner);
+    
     symbol token_symbol = symbol(token_code, DEFAULT_TOKEN_PRECISION);
+    double maximum_supply = DEFAULT_MAX_SUPPLY;
 
     settings settings_table(get_self(), get_self().value);
     const auto& st = settings_table.get("settings"_n.value, "settings do not exist");

--- a/contracts/eos/MultiConverter/MultiConverter.cpp
+++ b/contracts/eos/MultiConverter/MultiConverter.cpp
@@ -8,44 +8,48 @@
 #include "../Token/Token.hpp"
 #include "MultiConverter.hpp"
 
-ACTION MultiConverter::create(name owner, asset initial_supply, asset maximum_supply) {
+ACTION MultiConverter::create(name owner, symbol_code token_code, double initial_supply, double maximum_supply) {
     require_auth(owner);
-    
+    symbol token_symbol = { token_code, DEFAULT_TOKEN_PRECISION };
+
     settings settings_table(get_self(), get_self().value);
     const auto& st = settings_table.get("settings"_n.value, "settings do not exist");
 
-    converters converters_table(get_self(), initial_supply.symbol.code().raw());
-    auto converter = converters_table.find(initial_supply.symbol.code().raw());
-
-    check(initial_supply.symbol == maximum_supply.symbol, "symbol mismatch");    
+    converters converters_table(get_self(), token_symbol.code().raw());
+    const auto& converter = converters_table.find(token_symbol.code().raw());
+  
     check(converter == converters_table.end(), "converter for the given symbol already exists");
-    check(initial_supply.amount > 0, "must have a non-zero initial supply");
+    check(initial_supply > 0, "must have a non-zero initial supply");
+    check(initial_supply / maximum_supply <= MAX_INITIAL_MAXIMUM_SUPPLY_RATIO , "the ratio between initial and max supply is too big");
     
     converters_table.emplace(owner, [&](auto& c) {
-        c.currency = initial_supply.symbol;
+        c.currency = token_symbol;
         c.owner = owner;
         c.enabled = false;
         c.launched = false;
         c.stake_enabled = false;
         c.fee = 0;
-    });    
+    });
+
+    asset initial_supply_asset = asset(initial_supply * pow(10, token_symbol.precision()) , token_symbol);
+    asset maximum_supply_asset = asset(maximum_supply * pow(10, token_symbol.precision()) , token_symbol);
 
     action( 
         permission_level{ st.multi_token, "active"_n },
         st.multi_token, "create"_n, 
-        make_tuple(get_self(), maximum_supply) 
+        make_tuple(get_self(), maximum_supply_asset) 
     ).send();
 
     action( 
         permission_level{ get_self(), "active"_n },
         st.multi_token, "issue"_n, 
-        make_tuple(get_self(), initial_supply, string("setup"))
+        make_tuple(get_self(), initial_supply_asset, string("setup"))
     ).send();
 
     action(
         permission_level{ get_self(), "active"_n },
         st.multi_token, "transfer"_n,
-        make_tuple(get_self(), owner, initial_supply, string("setup"))
+        make_tuple(get_self(), owner, initial_supply_asset, string("setup"))
     ).send();
 }
 

--- a/contracts/eos/MultiConverter/MultiConverter.hpp
+++ b/contracts/eos/MultiConverter/MultiConverter.hpp
@@ -214,7 +214,7 @@ CONTRACT MultiConverter : public eosio::contract { /*! \endcond */
          * @param initial_supply - initial supply of the smart token governed by the converter
          * @param maximum_supply - maximum supply of the smart token governed by the converter
          */
-        ACTION create(name owner, symbol_code token_code, double initial_supply, double maximum_supply);
+        ACTION create(name owner, symbol_code token_code, double initial_supply);
 
         /**
          * @brief deletes a converter with empty reserves
@@ -375,6 +375,8 @@ CONTRACT MultiConverter : public eosio::contract { /*! \endcond */
         constexpr static double MAX_RATIO = 1000000.0;
         constexpr static double MAX_FEE = 1000000.0;
         constexpr static double MAX_INITIAL_MAXIMUM_SUPPLY_RATIO = 0.7;
+
+        constexpr static double DEFAULT_MAX_SUPPLY = 10000000000.0000;
         constexpr static uint8_t DEFAULT_TOKEN_PRECISION = 4;
 
 }; /** @}*/

--- a/contracts/eos/MultiConverter/MultiConverter.hpp
+++ b/contracts/eos/MultiConverter/MultiConverter.hpp
@@ -214,7 +214,7 @@ CONTRACT MultiConverter : public eosio::contract { /*! \endcond */
          * @param initial_supply - initial supply of the smart token governed by the converter
          * @param maximum_supply - maximum supply of the smart token governed by the converter
          */
-        ACTION create(name owner, asset initial_supply, asset maximum_supply);
+        ACTION create(name owner, symbol_code token_code, double initial_supply, double maximum_supply);
 
         /**
          * @brief deletes a converter with empty reserves
@@ -374,5 +374,7 @@ CONTRACT MultiConverter : public eosio::contract { /*! \endcond */
         } 
         constexpr static double MAX_RATIO = 1000000.0;
         constexpr static double MAX_FEE = 1000000.0;
+        constexpr static double MAX_INITIAL_MAXIMUM_SUPPLY_RATIO = 0.7;
+        constexpr static uint8_t DEFAULT_TOKEN_PRECISION = 4;
 
 }; /** @}*/

--- a/test/eos/common/converter.js
+++ b/test/eos/common/converter.js
@@ -298,7 +298,7 @@ const setMultitoken = async function(actor, token = multiToken) {
     return result;
 }
 // Creates a converter (MultiConverter sub-converter)
-const createConverter = async function(owner, initial_supply, maximum_supply) {
+const createConverter = async function(owner, token_code, initial_supply, maximum_supply) {
     const result = await api.transact({ 
         actions: [{
             account: multiConverter,
@@ -309,6 +309,7 @@ const createConverter = async function(owner, initial_supply, maximum_supply) {
             }],
             data: {
                 owner,
+                token_code,
                 initial_supply,
                 maximum_supply
             }

--- a/test/eos/common/converter.js
+++ b/test/eos/common/converter.js
@@ -298,7 +298,7 @@ const setMultitoken = async function(actor, token = multiToken) {
     return result;
 }
 // Creates a converter (MultiConverter sub-converter)
-const createConverter = async function(owner, token_code, initial_supply, maximum_supply) {
+const createConverter = async function(owner, token_code, initial_supply) {
     const result = await api.transact({ 
         actions: [{
             account: multiConverter,
@@ -310,8 +310,7 @@ const createConverter = async function(owner, token_code, initial_supply, maximu
             data: {
                 owner,
                 token_code,
-                initial_supply,
-                maximum_supply
+                initial_supply
             }
         }]
     }, 

--- a/test/eos/multiConvert.test.js
+++ b/test/eos/multiConvert.test.js
@@ -592,4 +592,23 @@ describe('Test: multiConverter', () => {
         })
 
     })
+
+    describe('Input validations', async () => {
+        it('[fund] ensures assets with invalid precision are rejected', async () => {
+            await expectError( // last fund cleared the accounts row
+                fund(user1, '10000.0 BNTEOS'),
+                "symbol mismatch"
+            )
+            await expectError( // last fund cleared the accounts row
+                fund(user1, '10000.00000001 TKNA'),
+                "symbol mismatch"
+            )
+        });
+        it('[liquidate] ensures assets with invalid precision are rejected', async () => {
+            await expectError( 
+                transfer('bnt2eosrelay',  '1.00000000 BNTEOS', multiConverter ,user1, 'liquidate'),
+                'bad origin for this transfer'
+            )
+        });
+    });
 })

--- a/test/eos/multiConvert.test.js
+++ b/test/eos/multiConvert.test.js
@@ -70,29 +70,26 @@ describe('Test: multiConverter', () => {
         })
         it('setup converters', async function() {
             const AinitSupply = '1000.0000'
-            const AmaxSupply = '100000030.0096'
             const Asymbol = 'TKNA'
             
             const BinitSupply = '1000.0000'
-            const BmaxSupply = '10002012.1090'
             const Bsymbol = 'TKNB'
 
             const CinitSupply = '99000.00000000'
-            const CmaxSupply = '100000000.00000000'
             const Csymbol = 'BNTEOS'
 
             await expectNoError(
-                createConverter(user1, Asymbol, AinitSupply, AmaxSupply) 
+                createConverter(user1, Asymbol, AinitSupply) 
             )
             result = await getConverter(Asymbol)
             assert.equal(result.rows.length, 1)
             assert.equal(result.rows[0].fee, 0, "converter fee not set correctly - TKNA")
 
             await expectNoError(
-                createConverter(user2, Bsymbol, BinitSupply, BmaxSupply) 
+                createConverter(user2, Bsymbol, BinitSupply) 
             )
             await expectNoError(
-                createConverter(user1, Csymbol, CinitSupply, CmaxSupply) 
+                createConverter(user1, Csymbol, CinitSupply) 
             )
         })
         it('setup reserves', async function() {

--- a/test/eos/multiConvert.test.js
+++ b/test/eos/multiConvert.test.js
@@ -246,11 +246,11 @@ describe('Test: multiConverter', () => {
             let userSmartTokenBalanceBefore = parseFloat(result.rows[0].balance)
             
             await expectError( // insufficient balance in account row
-                fund(user1, '2000.00000000 BNTEOS'),
+                fund(user1, '2000.0000 BNTEOS'),
                 "insufficient balance"
             )
             await expectNoError(
-                fund(user1, '1000.00000000 BNTEOS')
+                fund(user1, '1000.0000 BNTEOS')
             )
 
             eosTemp = await getAccount(user1, "BNTEOS", "EOS");
@@ -259,7 +259,7 @@ describe('Test: multiConverter', () => {
             assert.equal(bntTemp.rows.length, 0, "was expecting to have no bank balance")
 
             await expectError( // last fund cleared the accounts row
-                fund(user1, '10000.00000000 BNTEOS'),
+                fund(user1, '10000.0000 BNTEOS'),
                 "cannot withdraw non-existant deposit"
             )
             
@@ -267,8 +267,8 @@ describe('Test: multiConverter', () => {
             result = await getBalance(user1, multiToken, 'BNTEOS')
             assert.equal(result.rows.length, 1)
             let userSmartTokenBalanceAfter = parseFloat(result.rows[0].balance)
-            let delta = (userSmartTokenBalanceAfter - userSmartTokenBalanceBefore).toFixed(8)
-            assert.equal(delta, '1000.00000000', 'incorrect BNTEOS issued')
+            let delta = (userSmartTokenBalanceAfter - userSmartTokenBalanceBefore).toFixed(4)
+            assert.equal(delta, '1000.0000', 'incorrect BNTEOS issued')
             
             // Get relay reserve - BNT
             result = await getReserve('BNT', multiConverter, 'BNTEOS')
@@ -300,7 +300,7 @@ describe('Test: multiConverter', () => {
             let userRelayBefore = result.rows[0].balance.split(' ')[0]
 
             await expectNoError( 
-                transfer(multiToken, '1000.00000000 BNTEOS', multiConverter, user1, 'liquidate')
+                transfer(multiToken, '1000.0000 BNTEOS', multiConverter, user1, 'liquidate')
             )
         
             result = await getBalance(user1, bntToken, 'BNT')
@@ -321,7 +321,7 @@ describe('Test: multiConverter', () => {
 
             result = await getBalance(user1, multiToken, 'BNTEOS')
             let userRelayAfter = result.rows[0].balance.split(' ')[0]
-            assert.equal((userRelayBefore - userRelayAfter).toFixed(8), '1000.00000000', 'smart token balance after is incorrect - BNTEOS')
+            assert.equal((userRelayBefore - userRelayAfter).toFixed(4), '1000.0000', 'smart token balance after is incorrect - BNTEOS')
         })
         it('ensures that converters balances sum is equal to the multiConverter\'s total BNT balance [Load Test]', async function () {
             this.timeout(10000)
@@ -563,7 +563,7 @@ describe('Test: multiConverter', () => {
             const [userEosBefore, userBntBefore] = await Promise.all([getAccount(user1, 'BNTEOS', 'EOS'), getAccount(user1, 'BNTEOS', 'BNT')])
 
             await expectNoError(
-                fund(user1, '148.50000000 BNTEOS')
+                fund(user1, '148.5000 BNTEOS')
             )
 
             result = await getAccount(user1, 'BNTEOS', 'EOS')
@@ -578,7 +578,7 @@ describe('Test: multiConverter', () => {
             const [userEosBefore2, userBntBefore2] = await Promise.all([getAccount(user1, 'BNTEOS', 'EOS'), getAccount(user1, 'BNTEOS', 'BNT')])
 
             await expectNoError(
-                fund(user1, '657.94500123 BNTEOS')
+                fund(user1, '657.9450 BNTEOS')
             )
 
             result = await getAccount(user1, 'BNTEOS', 'EOS')
@@ -587,7 +587,7 @@ describe('Test: multiConverter', () => {
             
             result = await getAccount(user1, 'BNTEOS', 'BNT')
             var balance = result.rows[0].quantity.split(' ')[0]
-            assert.equal(balance, new Decimal(Number(userBntBefore2.rows[0].quantity.split(' ')[0])).minus(6.57945002).toString(), 'BNT balance invalid')
+            assert.equal(balance, new Decimal(Number(userBntBefore2.rows[0].quantity.split(' ')[0])).minus(6.57945001).toString(), 'BNT balance invalid')
 
         })
 

--- a/test/eos/multiConvert.test.js
+++ b/test/eos/multiConvert.test.js
@@ -69,27 +69,30 @@ describe('Test: multiConverter', () => {
             )
         })
         it('setup converters', async function() {
-            let AinitSupply = '1000.0000 TKNA'
-            let AmaxSupply = '100000030.0096 TKNA'
+            const AinitSupply = '1000.0000'
+            const AmaxSupply = '100000030.0096'
+            const Asymbol = 'TKNA'
             
-            let BinitSupply = '1000.0000 TKNB'
-            let BmaxSupply = '10002012.1090 TKNB'
+            const BinitSupply = '1000.0000'
+            const BmaxSupply = '10002012.1090'
+            const Bsymbol = 'TKNB'
 
-            let CinitSupply = '99000.00000000 BNTEOS'
-            let CmaxSupply = '100000000.00000000 BNTEOS'
+            const CinitSupply = '99000.00000000'
+            const CmaxSupply = '100000000.00000000'
+            const Csymbol = 'BNTEOS'
 
             await expectNoError(
-                createConverter(user1, AinitSupply, AmaxSupply) 
+                createConverter(user1, Asymbol, AinitSupply, AmaxSupply) 
             )
-            result = await getConverter('TKNA')
+            result = await getConverter(Asymbol)
             assert.equal(result.rows.length, 1)
             assert.equal(result.rows[0].fee, 0, "converter fee not set correctly - TKNA")
 
             await expectNoError(
-                createConverter(user2, BinitSupply, BmaxSupply) 
+                createConverter(user2, Bsymbol, BinitSupply, BmaxSupply) 
             )
             await expectNoError(
-                createConverter(user1, CinitSupply, CmaxSupply) 
+                createConverter(user1, Csymbol, CinitSupply, CmaxSupply) 
             )
         })
         it('setup reserves', async function() {


### PR DESCRIPTION
Added: 
- `MultiConverter::create` now creates a token with a default token precision of 4.
- `MultiConverter::create` doesn't accept `maximum_supply` as an argument anymore.

Bug fixes:
- `MultiConverter::fund` - added symbol validation for incoming `asset`.