### PR TITLE
Bancor table schema migration

### DIFF
--- a/contracts/eos/BancorConverter/BancorConverter.cpp
+++ b/contracts/eos/BancorConverter/BancorConverter.cpp
@@ -172,7 +172,6 @@ ACTION BancorConverter::updatefee(symbol_code currency, uint64_t fee) {
 
 ACTION BancorConverter::setreserve(symbol_code converter_currency_code, symbol currency, name contract, uint64_t ratio) {
     converters converters_table(get_self(), get_self().value);
-
     const auto& converter = converters_table.get(converter_currency_code.raw(), "converter does not exist");
     require_auth(converter.owner);
 

--- a/contracts/eos/BancorConverter/BancorConverter.cpp
+++ b/contracts/eos/BancorConverter/BancorConverter.cpp
@@ -59,7 +59,7 @@ void BancorConverter::create(name owner, symbol_code token_code, double initial_
 }
 
 [[eosio::action]]
-void BancorConverter::setparams( const settings_params params )
+void BancorConverter::setsettings( const BancorConverter::settings_t params )
 {
     require_auth( get_self() );
     BancorConverter::settings _settings( get_self(), get_self().value );

--- a/contracts/eos/BancorConverter/BancorConverter.hpp
+++ b/contracts/eos/BancorConverter/BancorConverter.hpp
@@ -61,7 +61,7 @@ using namespace std;
 }
 
 /*! \cond DOCS_EXCLUDE */
-CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
+class BancorConverter : public contract { /*! \endcond */
     public:
         using contract::contract;
 
@@ -99,7 +99,7 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
          * @details SCOPE of this table is the converters' smart token symbol's `code().raw()` values
          * @{
          *//*! \cond DOCS_EXCLUDE */
-            TABLE reserve_t { /*! \endcond */
+            struct [[eosio::table("reserves")]] reserve_t { /*! \endcond */
                 /**
                  * @brief name of the account storing the token contract for this reserve's token
                  */
@@ -128,7 +128,7 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
          * @details SCOPE of this table is the converters' smart token symbol's `code().raw()` values
          * @{
          *//*! \cond DOCS_EXCLUDE */
-            TABLE converter_v2_t {
+            struct [[eosio::table("converter.v2")]] converter_v2_t {
                 /**
                  * @brief symbol of the smart token -- representing a share in the reserves of this converter
                  * @details PRIMARY KEY for this table is `currency.code().raw()`
@@ -197,7 +197,7 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
          * @details SCOPE of this table is the converters' smart token symbol's `code().raw()` values
          * @{
          *//*! \cond DOCS_EXCLUDE */
-            TABLE converter_t { /*! \endcond */
+            struct [[eosio::table("converters")]] converter_t { /*! \endcond */
                 /**
                  * @brief symbol of the smart token -- representing a share in the reserves of this converter
                  * @details PRIMARY KEY for this table is `currency.code().raw()`
@@ -231,7 +231,7 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
          * @details SCOPE of this table is the `name.value` of the liquidity provider, owner of the `quantity`
          * @{
          *//*! \cond DOCS_EXCLUDE */
-            TABLE account_t { /*! \endcond */
+            struct [[eosio::table("account")]] account_t { /*! \endcond */
                 /**
                  * @brief symbol of the smart token (a way to reference converters) this balance pertains to
                  */
@@ -266,13 +266,15 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
          * @param initial_supply - initial supply of the smart token governed by the converter
          * @param maximum_supply - maximum supply of the smart token governed by the converter
          */
-        ACTION create(name owner, symbol_code token_code, double initial_supply);
+        [[eosio::action]]
+        void create(name owner, symbol_code token_code, double initial_supply);
 
         /**
          * @brief deletes a converter with empty reserves
          * @param converter_currency_code - the currency code of the currency governed by the converter
          */
-        ACTION delconverter(symbol_code converter_currency_code);
+        [[eosio::action]]
+        void delconverter(symbol_code converter_currency_code);
 
         /**
          * @brief sets the bancor network settings
@@ -289,7 +291,8 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
          *     "staking": ""
          * }]' -p bancorcnvrtr
          */
-        ACTION setparams( const BancorConverter::settings_params params );
+        [[eosio::action]]
+        void setparams( const BancorConverter::settings_params params );
 
         /**
          * @brief may only set staking/voting contract for this multi-converter once
@@ -297,7 +300,8 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
          * @param protocol_feature - protocol feature
          * @param enabled - (true/false) to be enabled
          */
-        ACTION activate( const symbol_code currency, const name protocol_feature, const bool enabled );
+        [[eosio::action]]
+        void activate( const symbol_code currency, const name protocol_feature, const bool enabled );
 
         // the 4 actions below updates the converter settings, can only be called by the converter owner after creation
 
@@ -306,14 +310,16 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
          * @param currency - the currency symbol governed by the converter
          * @param new_owner - converter's new owner
          */
-        ACTION updateowner(symbol_code currency, name new_owner);
+        [[eosio::action]]
+        void updateowner(symbol_code currency, name new_owner);
 
         /**
          * @brief updates the converter fee
          * @param currency - the currency symbol governed by the converter
          * @param fee - the new fee % for this converter, must be lower than the maximum fee, 0-1000000
          */
-        ACTION updatefee(symbol_code currency, uint64_t fee);
+        [[eosio::action]]
+        void updatefee(symbol_code currency, uint64_t fee);
 
         /**
          * @brief initializes a new reserve in the converter
@@ -322,22 +328,25 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
          * @param contract - reserve token contract name
          * @param ratio - reserve ratio, percentage, 0-1000000
          */
-        ACTION setreserve(symbol_code converter_currency_code, symbol currency, name contract, uint64_t ratio);
+        [[eosio::action]]
+        void setreserve(symbol_code converter_currency_code, symbol currency, name contract, uint64_t ratio);
 
         /**
          * @brief deletes an empty reserve in the converter
          * @param converter - the currency code of the smart token governed by the converter
          * @param currency - reserve token currency code
          */
-        ACTION delreserve(symbol_code converter, symbol_code reserve);
+        [[eosio::action]]
+        void delreserve(symbol_code converter, symbol_code reserve);
 
         /**
          * @brief called by liquidity providers withdrawing "temporary balances" before `fund`ing them into the reserve
          * @param sender - sender of the quantity
          * @param quantity - amount to decrease the supply by (in the smart token)
          * @param converter_currency_code - the currency code of the currency governed by the converter
-        */
-        ACTION withdraw(name sender, asset quantity, symbol_code converter_currency_code);
+         */
+        [[eosio::action]]
+        void withdraw(name sender, asset quantity, symbol_code converter_currency_code);
 
         /**
          * @brief buys smart tokens with all connector tokens using the same percentage
@@ -346,8 +355,9 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
          * can only be called if the total ratio is exactly 100%
          * @param  sender - sender of the quantity
          * @param quantity - amount to increase the supply by (in the smart token)
-        */
-        ACTION fund(name sender, asset quantity);
+         */
+        [[eosio::action]]
+        void fund(name sender, asset quantity);
 
         /**
          * @brief transfer intercepts with standard transfer args
@@ -359,7 +369,7 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
          * @param quantity - the quantity for the transfer
          * @param memo - the memo for the transfer
          */
-        //[[eosio::on_notify("*::transfer")]]
+        [[eosio::on_notify("*::transfer")]]
         void on_transfer(name from, name to, asset quantity, string memo);
 
         [[eosio::action]]
@@ -373,9 +383,8 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
         typedef eosio::multi_index<"converters"_n, converter_t> converters;
         typedef eosio::multi_index<"reserves"_n, reserve_t> reserves;
         typedef eosio::multi_index<"accounts"_n, account_t,
-                        indexed_by<"bycnvrt"_n,
-                            const_mem_fun <account_t, uint128_t,
-                            &account_t::by_cnvrt >>> accounts;
+            indexed_by<"bycnvrt"_n, const_mem_fun <account_t, uint128_t, &account_t::by_cnvrt >>
+        > accounts;
 
         // migration table
         typedef eosio::multi_index<"converter.v2"_n, converter_v2_t> converters_v2;

--- a/contracts/eos/BancorConverter/BancorConverter.hpp
+++ b/contracts/eos/BancorConverter/BancorConverter.hpp
@@ -174,10 +174,10 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
                  * @example
                  * {
                  *   "key: "stake",
-                 *   "value": "true"
+                 *   "value": true
                  * }
                  */
-                map<name, name> protocol_features;
+                map<name, bool> protocol_features;
 
                 /**
                  * @brief [optional] additional metadata for converter
@@ -293,6 +293,14 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
         ACTION setstaking(name staking);
 
         /**
+         * @brief may only set staking/voting contract for this multi-converter once
+         * @param currency - currency converter symbol code
+         * @param protocol_feature - protocol feature
+         * @param enabled - (true/false) to be enabled
+         */
+        ACTION activate( const symbol_code currency, const name protocol_feature, const bool enabled );
+
+        /**
          * @brief modify maxfee in this multi-converter's settings
          * @param maxfee - maximum fee for all converters in this multi-converter
          */
@@ -319,13 +327,6 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
          * @param fee - the new fee % for this converter, must be lower than the maximum fee, 0-1000000
          */
         ACTION updatefee(symbol_code currency, uint64_t fee);
-
-        /**
-         * @brief flag indicating if the smart token can be staked, false if not
-         * @param currency - the currency symbol governed by the converter
-         * @param enabled - true if staking/voting for this symbol are enabled
-         */
-        ACTION enablestake(symbol_code currency, bool enabled);
 
         /**
          * @brief initializes a new reserve in the converter

--- a/contracts/eos/BancorConverter/BancorConverter.hpp
+++ b/contracts/eos/BancorConverter/BancorConverter.hpp
@@ -71,7 +71,7 @@ class BancorConverter : public contract { /*! \endcond */
          * @details Both SCOPE and PRIMARY KEY are `_self`, so this table is effectively a singleton
          * @{
          *//*! \cond DOCS_EXCLUDE */
-            struct [[eosio::table("settings")]] settings_params { /*! \endcond */
+            struct [[eosio::table("settings")]] settings_t { /*! \endcond */
                 /**
                  * @brief maximum conversion fee for converters in this contract
                  */
@@ -277,14 +277,14 @@ class BancorConverter : public contract { /*! \endcond */
         void delconverter(symbol_code converter_currency_code);
 
         /**
-         * @brief sets the bancor network settings
+         * @brief sets the bancor settings
          * @param multi_token - may only set multi-token contract once
          * @param staking - name of staking/voting contract
          * @param maxfee - maximum fee for all converters in this multi-converter
          * @param network - bancor network contract account
          * @example
          *
-         * cleos push action bancorcnvrtr setparams '[{
+         * cleos push action bancorcnvrtr setsettings '[{
          *     "max_fee": 30000,
          *     "multi_token": "smarttokens1",
          *     "network": "thisisbancor",
@@ -292,7 +292,7 @@ class BancorConverter : public contract { /*! \endcond */
          * }]' -p bancorcnvrtr
          */
         [[eosio::action]]
-        void setparams( const BancorConverter::settings_params params );
+        void setsettings( const BancorConverter::settings_t params );
 
         /**
          * @brief may only set staking/voting contract for this multi-converter once
@@ -379,7 +379,7 @@ class BancorConverter : public contract { /*! \endcond */
         void delmigrate( const set<symbol_code> converters );
 
         /*! \cond DOCS_EXCLUDE */
-        typedef eosio::singleton<"settings"_n, settings_params> settings;
+        typedef eosio::singleton<"settings"_n, settings_t> settings;
         typedef eosio::multi_index<"converters"_n, converter_t> converters;
         typedef eosio::multi_index<"reserves"_n, reserve_t> reserves;
         typedef eosio::multi_index<"accounts"_n, account_t,

--- a/contracts/eos/BancorConverter/BancorConverter.hpp
+++ b/contracts/eos/BancorConverter/BancorConverter.hpp
@@ -132,7 +132,7 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
          * @details SCOPE of this table is the converters' smart token symbol's `code().raw()` values
          * @{
          *//*! \cond DOCS_EXCLUDE */
-            TABLE reserve_v2_t {
+            TABLE converter_v2_t {
                 /**
                  * @brief symbol of the smart token -- representing a share in the reserves of this converter
                  * @details PRIMARY KEY for this table is `currency.code().raw()`
@@ -140,14 +140,29 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
                 symbol currency;
 
                 /**
-                 * @brief reserve ratios relative to the other reserves
+                 * @brief creator of the converter
                  */
-                map<symbol_code, uint64_t> ratios;
+                name owner;
+
+                /**
+                 * @brief toggle boolean to enable/disable this staking and voting for this converter
+                 */
+                bool stake_enabled;
+
+                /**
+                 * @brief conversion fee for this converter, applied on every hop
+                 */
+                uint64_t fee;
+
+                /**
+                 * @brief reserve weights relative to the other reserves
+                 */
+                map<symbol_code, uint64_t> reserve_weights;
 
                 /**
                  * @brief balances in each reserve
                  */
-                map<symbol_code, extended_asset> balances;
+                map<symbol_code, extended_asset> reserve_balances;
 
                 /*! \cond DOCS_EXCLUDE */
                 uint64_t primary_key() const { return currency.code().raw(); }
@@ -347,7 +362,7 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
                             &account_t::by_cnvrt >>> accounts;
 
         // migration table
-        typedef eosio::multi_index<"reserves.v2"_n, reserve_v2_t> reserves_v2;
+        typedef eosio::multi_index<"converter.v2"_n, converter_v2_t> converters_v2;
 
         /*! \endcond */
 
@@ -404,7 +419,7 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
         constexpr static uint8_t DEFAULT_TOKEN_PRECISION = 4;
 
         // migration
-        symbol migrate_converter( const symbol_code symcode );
-        void migrate_reserve( const symbol currency );
+        void migrate_converters_v1_no_scope( const symbol_code symcode );
+        void migrate_converters_v2( const symbol_code symcode );
 
 }; /** @}*/

--- a/contracts/eos/BancorConverter/BancorConverter.hpp
+++ b/contracts/eos/BancorConverter/BancorConverter.hpp
@@ -145,24 +145,49 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
                 name owner;
 
                 /**
-                 * @brief toggle boolean to enable/disable this staking and voting for this converter
-                 */
-                bool stake_enabled;
-
-                /**
                  * @brief conversion fee for this converter, applied on every hop
                  */
                 uint64_t fee;
 
                 /**
                  * @brief reserve weights relative to the other reserves
+                 * @example
+                 * {
+                 *   "key: "BNT",
+                 *   "value": 500000
+                 * }
                  */
                 map<symbol_code, uint64_t> reserve_weights;
 
                 /**
                  * @brief balances in each reserve
+                 * @example
+                 * {
+                 *   "key: "BNT",
+                 *   "value": "10000.0000 BNT"
+                 * }
                  */
                 map<symbol_code, extended_asset> reserve_balances;
+
+                /**
+                 * @brief [optional] protocol features for converter
+                 * @example
+                 * {
+                 *   "key: "stake",
+                 *   "value": "true"
+                 * }
+                 */
+                map<name, name> protocol_features;
+
+                /**
+                 * @brief [optional] additional metadata for converter
+                 * @example
+                 * {
+                 *   "key: "website",
+                 *   "value": "https://mywebsite.com"
+                 * }
+                 */
+                map<name, string> metadata_json;
 
                 /*! \cond DOCS_EXCLUDE */
                 uint64_t primary_key() const { return currency.code().raw(); }

--- a/contracts/eos/BancorConverter/BancorConverter.hpp
+++ b/contracts/eos/BancorConverter/BancorConverter.hpp
@@ -377,6 +377,9 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
         [[eosio::action]]
         void migrate( const set<symbol_code> converters );
 
+        [[eosio::action]]
+        void delmigrate( const set<symbol_code> converters );
+
         /*! \cond DOCS_EXCLUDE */
         typedef eosio::multi_index<"settings"_n, settings_t> settings;
         typedef eosio::multi_index<"converters"_n, converter_t> converters;
@@ -399,7 +402,6 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
         using setmaxfee_action = action_wrapper<"setmaxfee"_n, &BancorConverter::setmaxfee>;
         using updateowner_action = action_wrapper<"updateowner"_n, &BancorConverter::updateowner>;
         using updatefee_action = action_wrapper<"updatefee"_n, &BancorConverter::updatefee>;
-        using enablestake_action = action_wrapper<"enablestake"_n, &BancorConverter::enablestake>;
         using setreserve_action = action_wrapper<"setreserve"_n, &BancorConverter::setreserve>;
         using delreserve_action = action_wrapper<"delreserve"_n, &BancorConverter::delreserve>;
         using withdraw_action = action_wrapper<"withdraw"_n, &BancorConverter::withdraw>;
@@ -446,5 +448,6 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
         // migration
         void migrate_converters_v1_no_scope( const symbol_code symcode );
         void migrate_converters_v2( const symbol_code symcode );
+        void delete_converters_v2( const symbol_code symcode );
 
 }; /** @}*/

--- a/contracts/eos/BancorConverter/BancorConverter.hpp
+++ b/contracts/eos/BancorConverter/BancorConverter.hpp
@@ -342,8 +342,9 @@ CONTRACT BancorConverter : public eosio::contract { /*! \endcond */
         typedef eosio::multi_index<"converters"_n, converter_t> converters;
         typedef eosio::multi_index<"reserves"_n, reserve_t> reserves;
         typedef eosio::multi_index<"accounts"_n, account_t,
-            indexed_by<"bycnvrt"_n, const_mem_fun <account_t, uint128_t, &account_t::by_cnvrt >>
-        > accounts;
+                        indexed_by<"bycnvrt"_n,
+                            const_mem_fun <account_t, uint128_t,
+                            &account_t::by_cnvrt >>> accounts;
 
         // migration table
         typedef eosio::multi_index<"reserves.v2"_n, reserve_v2_t> reserves_v2;

--- a/contracts/eos/BancorConverter/migrate.cpp
+++ b/contracts/eos/BancorConverter/migrate.cpp
@@ -1,6 +1,8 @@
 [[eosio::action]]
 void BancorConverter::migrate( const set<symbol_code> converters )
 {
+    require_auth( get_self() );
+
     for ( const symbol_code symcode : converters ) {
         migrate_converters_v1_no_scope( symcode );
         migrate_converters_v2( symcode );

--- a/contracts/eos/BancorConverter/migrate.cpp
+++ b/contracts/eos/BancorConverter/migrate.cpp
@@ -74,7 +74,6 @@ void BancorConverter::migrate_converters_v2( const symbol_code symcode )
 
             // converter
             row.owner = converter.owner;
-            row.stake_enabled = converter.stake_enabled;
             row.fee = converter.fee;
 
             // reserve
@@ -86,7 +85,6 @@ void BancorConverter::migrate_converters_v2( const symbol_code symcode )
         converters_v2.modify(reserve_itr_v2, get_self(), [&](auto& row) {
             // converter
             row.owner = converter.owner;
-            row.stake_enabled = converter.stake_enabled;
             row.fee = converter.fee;
 
             // reserve

--- a/contracts/eos/BancorConverter/migrate.cpp
+++ b/contracts/eos/BancorConverter/migrate.cpp
@@ -1,0 +1,79 @@
+[[eosio::action]]
+void BancorConverter::migrate( const set<symbol_code> converters )
+{
+    for ( const symbol_code symcode : converters ) {
+        const symbol currency = migrate_converter( symcode );
+        migrate_reserve( currency );
+    }
+}
+
+symbol BancorConverter::migrate_converter( const symbol_code symcode )
+{
+    // tables
+    converters converters_table_scope( get_self(), symcode.raw() );
+    converters converters_table_no_scope( get_self(), get_self().value );
+
+    // iterators
+    auto converter_itr_scope = converters_table_scope.find( symcode.raw() );
+    auto converter_itr_no_scope = converters_table_no_scope.find( symcode.raw() );
+
+    // scoped symbol code must exists
+    check( converter_itr_scope != converters_table_scope.end(), symcode.to_string() + " currency symbol code does not exists" );
+
+    // create
+    if ( converter_itr_no_scope == converters_table_no_scope.end() ) {
+        // add v1 converters to main scope
+        converters_table_no_scope.emplace(get_self(), [&](auto& row) {
+            row.currency = converter_itr_scope->currency;
+            row.owner = converter_itr_scope->owner;
+            row.stake_enabled = converter_itr_scope->stake_enabled;
+            row.fee = converter_itr_scope->fee;
+        });
+    // modify
+    } else {
+        converters_table_no_scope.modify(converter_itr_no_scope, get_self(), [&](auto& row) {
+            row.currency = converter_itr_scope->currency;
+            row.owner = converter_itr_scope->owner;
+            row.stake_enabled = converter_itr_scope->stake_enabled;
+            row.fee = converter_itr_scope->fee;
+        });
+    }
+    // currency to be used for reserve migration
+    return converter_itr_scope->currency;
+}
+
+void BancorConverter::migrate_reserve( const symbol currency )
+{
+    // tables
+    reserves reserves_table_v1( get_self(), currency.code().raw() );
+    reserves_v2 reserves_table_v2( get_self(), get_self().value );
+
+    // create empty map objects of ratios & balances
+    map<symbol_code, uint64_t> ratios;
+    map<symbol_code, extended_asset> balances;
+
+    for ( const auto reserve: reserves_table_v1 ) {
+        const symbol_code symcode = reserve.balance.symbol.code();
+        ratios[symcode] = reserve.ratio;
+        balances[symcode] = extended_asset{reserve.balance, reserve.contract};
+    }
+
+    // iterators
+    auto reserve_itr_v2 = reserves_table_v2.find( currency.code().raw() );
+
+    // create v2 reserve to main scope
+    if ( reserve_itr_v2 == reserves_table_v2.end() ) {
+        reserves_table_v2.emplace(get_self(), [&](auto& row) {
+            row.currency = currency;
+            row.ratios = ratios;
+            row.balances = balances;
+        });
+    // modify
+    } else {
+        reserves_table_v2.modify(reserve_itr_v2, get_self(), [&](auto& row) {
+            row.currency = currency;
+            row.ratios = ratios;
+            row.balances = balances;
+        });
+    }
+}

--- a/contracts/eos/BancorConverter/migrate.cpp
+++ b/contracts/eos/BancorConverter/migrate.cpp
@@ -9,6 +9,16 @@ void BancorConverter::migrate( const set<symbol_code> converters )
     }
 }
 
+[[eosio::action]]
+void BancorConverter::delmigrate( const set<symbol_code> converters )
+{
+    require_auth( get_self() );
+
+    for ( const symbol_code symcode : converters ) {
+        delete_converters_v2( symcode );
+    }
+}
+
 void BancorConverter::migrate_converters_v1_no_scope( const symbol_code symcode )
 {
     // tables
@@ -91,5 +101,16 @@ void BancorConverter::migrate_converters_v2( const symbol_code symcode )
             row.reserve_weights = reserve_weights;
             row.reserve_balances = reserve_balances;
         });
+    }
+}
+
+void BancorConverter::delete_converters_v2( const symbol_code symcode )
+{
+    // tables
+    converters_v2 converters_v2( get_self(), get_self().value );
+    auto itr = converters_v2.find( symcode.raw() );
+
+    if ( itr != converters_v2.end() ) {
+        converters_v2.erase( itr );
     }
 }

--- a/scripts/get_scopes.js
+++ b/scripts/get_scopes.js
@@ -1,0 +1,19 @@
+const { createDfuseClient } = require("@dfuse/client")
+const { name, symbol_code } = require("eos-common");
+
+global.fetch = require("node-fetch")
+global.WebSocket = require("ws")
+
+const client = createDfuseClient({ apiKey: process.env.DFUSE_API_KEY, network: "mainnet" })
+
+async function main() {
+    const results = await client.stateTableScopes("bancorcnvrtr", "converters");
+
+    for ( const scope of results.scopes ) {
+        const symcode = symbol_code( name(scope).value ).to_string();
+        console.log(symcode);
+    }
+    client.release()
+}
+
+main();


### PR DESCRIPTION
## Converters

No significant changes, simply added scoped data to main scope `get_self()`

Will be used right away in new migration upgrade

## Reserves

Removal of scopes requires the `currency` symbol code as scope and `map` objects for `ratios` & `balances`.

**before**

```c++
TABLE reserve_t {
    name contract;
    uint64_t ratio;
    asset balance;

    uint64_t primary_key() const { return balance.symbol.code().raw(); }
};
```

**after**
```c++
TABLE reserve_v2_t {
    symbol currency;
    map<symbol_code, uint64_t> ratios;
    map<symbol_code, extended_asset> balances;

    uint64_t primary_key() const { return currency.code().raw(); }
};
```

## How to migrate

Once code is deployed, `migrate` action must be called on all the currently active converters, this will update the `converters` table to use the main scope and `reserves.v2` table will be populated using `reserves` legacy table structure.

```bash
cleos push action bancorcnvrtr migrate '[["BNTEOS"]]' -p myaccount
```

![image](https://user-images.githubusercontent.com/550895/81136802-94702f80-8f2a-11ea-890d-4d234ee9c464.png)

## TO-DO

- [x] list all active converters with their symbol code
- [x] simple script to check accuracy between reserves
- [x] include `migrate_reserve` to main code, continuously updates after initial migrate step