### PR TITLE
Refactoring changes

### DIFF
--- a/contracts/eos/BancorConverter/BancorConverter.hpp
+++ b/contracts/eos/BancorConverter/BancorConverter.hpp
@@ -440,6 +440,10 @@ class [[eosio::contract]] BancorConverter : public contract { /*! \endcond */
         constexpr static double DEFAULT_MAX_SUPPLY = 10000000000.0000;
         constexpr static uint8_t DEFAULT_TOKEN_PRECISION = 4;
 
+        // utils
+        double asset_to_double( const asset quantity );
+        asset double_to_asset( const double amount, const symbol sym );
+
         // migration
         void migrate_converters_v1_no_scope( const symbol_code symcode );
         void migrate_converters_v2( const symbol_code symcode );

--- a/contracts/eos/BancorConverter/src/convert.cpp
+++ b/contracts/eos/BancorConverter/src/convert.cpp
@@ -36,8 +36,8 @@ void BancorConverter::convert(name from, asset quantity, string memo, name code)
 
     EMIT_CONVERSION_EVENT(
         converter.currency.code(), memo, from_token.contract, from_path_currency, to_token.get_contract(), to_path_currency,
-        quantity.amount / pow(10, quantity.symbol.precision()),
-        to_return.amount / pow(10, to_return.symbol.precision()),
+        asset_to_double(quantity),
+        asset_to_double(to_return),
         fee
     );
 
@@ -59,15 +59,15 @@ std::tuple<asset, double> BancorConverter::calculate_return(extended_asset from_
     reserve_t input_reserve, to_reserve;
     if (!incoming_smart_token) {
         input_reserve = get_reserve(from_symbol.code(), converter.currency.code());
-        current_from_balance = input_reserve.balance.amount / pow(10, input_reserve.balance.symbol.precision());
+        current_from_balance = asset_to_double(input_reserve.balance);
     }
     if (!outgoing_smart_token) {
         to_reserve = get_reserve(to_symbol.code(), converter.currency.code());
-        current_to_balance = to_reserve.balance.amount / pow(10, to_reserve.balance.symbol.precision());
+        current_to_balance = asset_to_double(to_reserve.balance);
     }
     bool quick_conversion = !incoming_smart_token && !outgoing_smart_token && input_reserve.ratio == to_reserve.ratio;
 
-    double from_amount = from_token.quantity.amount / pow(10, from_symbol.precision());
+    double from_amount = asset_to_double(from_token.quantity);
     double to_amount;
     if (quick_conversion) { // Reserve --> Reserve
         to_amount = quick_convert(current_from_balance, from_amount, current_to_balance);
@@ -88,7 +88,7 @@ std::tuple<asset, double> BancorConverter::calculate_return(extended_asset from_
     to_amount -= fee;
 
     return std::tuple(
-        asset(to_amount * pow(10, to_symbol.precision()), to_symbol),
+        double_to_asset(to_amount, to_symbol),
         to_fixed(fee, to_symbol.precision())
     );
 }

--- a/contracts/eos/BancorConverter/src/convert.cpp
+++ b/contracts/eos/BancorConverter/src/convert.cpp
@@ -3,14 +3,14 @@ void BancorConverter::convert(name from, asset quantity, string memo, name code)
     const auto& settings = settings_table.get();
     check(from == settings.network, "converter can only receive from network contract");
 
-    memo_structure memo_object = parse_memo(memo);
+    const memo_structure memo_object = parse_memo(memo);
     check(memo_object.path.size() > 1, "invalid memo format");
     check(memo_object.converters[0].account == get_self(), "wrong converter");
 
-    symbol_code from_path_currency = quantity.symbol.code();
-    symbol_code to_path_currency = symbol_code(memo_object.path[1].c_str());
+    const symbol_code from_path_currency = quantity.symbol.code();
+    const symbol_code to_path_currency = symbol_code(memo_object.path[1].c_str());
 
-    symbol_code converter_currency_code = symbol_code(memo_object.converters[0].sym);
+    const symbol_code converter_currency_code = symbol_code(memo_object.converters[0].sym);
     converters converters_table(get_self(), get_self().value);
     const auto& converter = converters_table.get(converter_currency_code.raw(), "converter does not exist");
 
@@ -20,7 +20,7 @@ void BancorConverter::convert(name from, asset quantity, string memo, name code)
         code == get_reserve(from_path_currency, converter.currency.code()).contract
         , "unknown 'from' contract");
 
-    extended_asset from_token = extended_asset(quantity, code);
+    const extended_asset from_token = extended_asset(quantity, code);
     extended_symbol to_token;
     if (to_path_currency == converter.currency.code()) {
         check(memo_object.path.size() == 2, "smart token must be final currency");
@@ -46,13 +46,13 @@ void BancorConverter::convert(name from, asset quantity, string memo, name code)
 }
 
 std::tuple<asset, double> BancorConverter::calculate_return(extended_asset from_token, extended_symbol to_token, string memo, const converter_t& converter, name multi_token) {
-    symbol from_symbol = from_token.quantity.symbol;
-    symbol to_symbol = to_token.get_symbol();
+    const symbol from_symbol = from_token.quantity.symbol;
+    const symbol to_symbol = to_token.get_symbol();
 
-    bool incoming_smart_token = from_symbol == converter.currency;
-    bool outgoing_smart_token = to_symbol == converter.currency;
+    const bool incoming_smart_token = from_symbol == converter.currency;
+    const bool outgoing_smart_token = to_symbol == converter.currency;
 
-    asset supply = get_supply(multi_token, converter.currency.code());
+    const asset supply = get_supply(multi_token, converter.currency.code());
     double current_smart_supply = supply.amount / pow(10, converter.currency.precision());
 
     double current_from_balance, current_to_balance;
@@ -65,7 +65,7 @@ std::tuple<asset, double> BancorConverter::calculate_return(extended_asset from_
         to_reserve = get_reserve(to_symbol.code(), converter.currency.code());
         current_to_balance = asset_to_double(to_reserve.balance);
     }
-    bool quick_conversion = !incoming_smart_token && !outgoing_smart_token && input_reserve.ratio == to_reserve.ratio;
+    const bool quick_conversion = !incoming_smart_token && !outgoing_smart_token && input_reserve.ratio == to_reserve.ratio;
 
     double from_amount = asset_to_double(from_token.quantity);
     double to_amount;
@@ -83,8 +83,8 @@ std::tuple<asset, double> BancorConverter::calculate_return(extended_asset from_
         }
     }
 
-    uint8_t magnitude = incoming_smart_token || outgoing_smart_token ? 1 : 2;
-    double fee = calculate_fee(to_amount, converter.fee, magnitude);
+    const uint8_t magnitude = incoming_smart_token || outgoing_smart_token ? 1 : 2;
+    const double fee = calculate_fee(to_amount, converter.fee, magnitude);
     to_amount -= fee;
 
     return std::tuple(

--- a/contracts/eos/BancorConverter/src/converters.cpp
+++ b/contracts/eos/BancorConverter/src/converters.cpp
@@ -23,8 +23,8 @@ void BancorConverter::create(name owner, symbol_code token_code, double initial_
         c.fee = 0;
     });
 
-    asset initial_supply_asset = asset(initial_supply * pow(10, token_symbol.precision()) , token_symbol);
-    asset maximum_supply_asset = asset(maximum_supply * pow(10, token_symbol.precision()) , token_symbol);
+    const asset initial_supply_asset = double_to_asset(initial_supply, token_symbol);
+    const asset maximum_supply_asset = double_to_asset(maximum_supply, token_symbol);
 
     action(
         permission_level{ st.multi_token, "active"_n },

--- a/contracts/eos/BancorConverter/src/converters.cpp
+++ b/contracts/eos/BancorConverter/src/converters.cpp
@@ -4,7 +4,7 @@ void BancorConverter::create(name owner, symbol_code token_code, double initial_
 
     check( token_code.is_valid(), "token_code is invalid");
     symbol token_symbol = symbol(token_code, DEFAULT_TOKEN_PRECISION);
-    double maximum_supply = DEFAULT_MAX_SUPPLY;
+    const double maximum_supply = DEFAULT_MAX_SUPPLY;
 
     settings settings_table(get_self(), get_self().value);
     const auto& st = settings_table.get();

--- a/contracts/eos/BancorConverter/src/reserves.cpp
+++ b/contracts/eos/BancorConverter/src/reserves.cpp
@@ -53,7 +53,7 @@ void BancorConverter::fund(name sender, asset quantity) {
     const auto& converter = converters_table.get(quantity.symbol.code().raw(), "converter does not exist");
 
     check(converter.currency == quantity.symbol, "symbol mismatch");
-    asset supply = get_supply(st.multi_token, quantity.symbol.code());
+    const asset supply = get_supply(st.multi_token, quantity.symbol.code());
     reserves reserves_table(get_self(), quantity.symbol.code().raw());
 
     double total_ratio = 0.0;
@@ -112,7 +112,7 @@ void BancorConverter::liquidate(name sender, asset quantity) {
     const auto& st = settings_table.get();
     check(get_first_receiver() == st.multi_token, "bad origin for this transfer");
 
-    asset supply = get_supply(st.multi_token, quantity.symbol.code());
+    const asset supply = get_supply(st.multi_token, quantity.symbol.code());
     reserves reserves_table(get_self(), quantity.symbol.code().raw());
 
     double total_ratio = 0.0;

--- a/contracts/eos/BancorConverter/src/utils.cpp
+++ b/contracts/eos/BancorConverter/src/utils.cpp
@@ -51,3 +51,12 @@ double BancorConverter::calculate_sale_return(double balance, double sell_amount
 double BancorConverter::quick_convert(double balance, double in, double toBalance) {
     return in / (balance + in) * toBalance;
 }
+
+double BancorConverter::asset_to_double( const asset quantity ) {
+    if ( quantity.amount == 0 ) return 0.0;
+    return quantity.amount / pow(10, quantity.symbol.precision());
+}
+
+asset BancorConverter::double_to_asset( const double amount, const symbol sym ) {
+    return asset{ static_cast<int64_t>(amount * pow(10, sym.precision())), sym };
+}


### PR DESCRIPTION
## Refactoring

- [x] replace using `asset_to_double` & `double_to_asset` (simplifies code logic) https://github.com/bancorprotocol/contracts_eos/pull/68/commits/b3ca13d18ece997491e1a4d624efb01452de9306
- [x] use `const` for variables that are not being modified after being declared https://github.com/bancorprotocol/contracts_eos/pull/68/commits/158bf4b7234ab113be9ea8c0cacdf7f95c3bf1f8
- [ ] replace `EMIT_CONVERSION_EVENT` with `log` inline action
- [ ] replace `action().send()` with `static_action`
