### PR TITLE
Sync tables process

### DIFF
--- a/contracts/eos/BancorConverter/scripts/test.sh
+++ b/contracts/eos/BancorConverter/scripts/test.sh
@@ -24,7 +24,13 @@ cleos transfer myaccount bancorcnvrtr "500.0000000000 BNT" "fund;EOSBNT" --contr
 cleos transfer myaccount bancorcnvrtr "500.0000 EOS" "fund;EOSBNT"
 cleos push action bancorcnvrtr fund '["myaccount", "500.0000 EOSBNT"]' -p myaccount
 
+# liquidate
+cleos transfer myaccount bancorcnvrtr "500.0000 EOSBNT" "liquidate" --contract smarttokens1
+
 # convert
 cleos transfer myaccount thisisbancor "10.0000 EOS" "1,bancorcnvrtr:EOSBNT BNT,0.0,myaccount"
 cleos transfer myaccount thisisbancor "9.8360655737 BNT" "1,bancorcnvrtr:EOSBNT EOS,0.0,myaccount" --contract bntbntbntbnt
 # //=> should return 10 EOS (9.9999 EOS)
+
+# sync (MIGRATION)
+cleos push action bancorcnvrtr synctables '[["EOSBNT"]]' -p bancorcnvrtr

--- a/contracts/eos/BancorConverter/src/convert.cpp
+++ b/contracts/eos/BancorConverter/src/convert.cpp
@@ -119,4 +119,8 @@ void BancorConverter::apply_conversion(memo_structure memo_object, extended_asse
     const auto settings = _settings.get();
     Token::transfer_action transfer( to_return.contract, { get_self(), "active"_n });
     transfer.send(get_self(), settings.network, to_return.quantity, new_memo);
+
+    // sync (MIGRATION ONLY)
+    BancorConverter::synctable_action synctable( get_self(), { get_self(), "active"_n });
+    synctable.send( converter_currency.code() );
 }

--- a/contracts/eos/BancorConverter/src/converters.cpp
+++ b/contracts/eos/BancorConverter/src/converters.cpp
@@ -40,6 +40,10 @@ void BancorConverter::create(const name owner, const symbol_code token_code, con
     // transfer
     Token::transfer_action transfer( multi_token, { get_self(), "active"_n });
     transfer.send(get_self(), owner, initial_supply_asset, "setup");
+
+    // sync (MIGRATION ONLY)
+    BancorConverter::synctable_action synctable( get_self(), { get_self(), "active"_n });
+    synctable.send( token_code );
 }
 
 [[eosio::action]]

--- a/contracts/eos/BancorConverter/src/migrate.cpp
+++ b/contracts/eos/BancorConverter/src/migrate.cpp
@@ -15,30 +15,67 @@ void BancorConverter::cleartables( const set<symbol_code> currencies )
     require_auth( get_self() );
 
     for ( const symbol_code symcode : currencies ) {
-        erase_converters_v1( symcode );
-        erase_converters_v1_scoped( symcode );
-        erase_reserves_v1( symcode );
+        // erase_converters_v1( symcode );
+        // erase_converters_v1_scoped( symcode );
+        // erase_reserves_v1( symcode );
     }
 }
 
-void BancorConverter::erase_converters_v1( const symbol_code symcode )
+[[eosio::action]]
+void BancorConverter::synctables( const set<symbol_code> currencies )
 {
-    BancorConverter::converters _converters( get_self(), get_self().value );
-    auto itr = _converters.find( symcode.raw() );
-    if ( itr != _converters.end() ) _converters.erase( itr );
+    require_auth( get_self() );
+
+    for ( const symbol_code symcode : currencies ) {
+        synctable( symcode );
+    }
 }
 
-void BancorConverter::erase_converters_v1_scoped( const symbol_code symcode )
+[[eosio::action]]
+void BancorConverter::synctable( const symbol_code currency )
 {
-    BancorConverter::converters _converters( get_self(), symcode.raw() );
-    clear_table( _converters );
+    require_auth( get_self() );
+
+    BancorConverter::converters_v2 _converters_v2(get_self(), get_self().value);
+    BancorConverter::converters _converters(get_self(), get_self().value);
+
+    auto itr_v2 = _converters_v2.find( currency.raw() );
+    auto itr = _converters.find( currency.raw() );
+
+    // clone previous table data
+    auto insert = [&]( auto & row ) {
+        row.currency = itr_v2->currency;
+        row.owner = itr_v2->owner;
+        row.fee = itr_v2->fee;
+        row.reserve_weights = itr_v2->reserve_weights;
+        row.reserve_balances = itr_v2->reserve_balances;
+        row.protocol_features = itr_v2->protocol_features;
+        row.metadata_json = itr_v2->metadata_json;
+    };
+
+    // create or modify
+    if ( itr == _converters.end() ) _converters.emplace( get_self(), insert );
+    else _converters.modify( itr, get_self(), insert );
 }
 
-void BancorConverter::erase_reserves_v1( const symbol_code symcode )
-{
-    BancorConverter::reserves _reserves( get_self(), symcode.raw() );
-    clear_table( _reserves );
-}
+// void BancorConverter::erase_converters_v1( const symbol_code symcode )
+// {
+//     BancorConverter::converters _converters( get_self(), get_self().value );
+//     auto itr = _converters.find( symcode.raw() );
+//     if ( itr != _converters.end() ) _converters.erase( itr );
+// }
+
+// void BancorConverter::erase_converters_v1_scoped( const symbol_code symcode )
+// {
+//     BancorConverter::converters _converters( get_self(), symcode.raw() );
+//     clear_table( _converters );
+// }
+
+// void BancorConverter::erase_reserves_v1( const symbol_code symcode )
+// {
+//     BancorConverter::reserves _reserves( get_self(), symcode.raw() );
+//     clear_table( _reserves );
+// }
 
 template <typename T>
 void BancorConverter::clear_table( T& table )

--- a/contracts/eos/BancorConverter/src/modify_balance.cpp
+++ b/contracts/eos/BancorConverter/src/modify_balance.cpp
@@ -43,6 +43,10 @@ void BancorConverter::mod_balances( name sender, asset quantity, symbol_code con
         check(sender == converter.owner, "only converter owner may fund/withdraw prior to activation");
         mod_reserve_balance(converter.currency, quantity);
     }
+
+    // sync (MIGRATION ONLY)
+    BancorConverter::synctable_action synctable( get_self(), { get_self(), "active"_n });
+    synctable.send( converter_currency_code );
 }
 
 void BancorConverter::mod_reserve_balance(symbol converter_currency, asset value, int64_t pending_supply_change) {

--- a/contracts/eos/BancorConverter/src/reserves.cpp
+++ b/contracts/eos/BancorConverter/src/reserves.cpp
@@ -83,6 +83,10 @@ void BancorConverter::fund( const name sender, const asset quantity ) {
 
     Token::transfer_action transfer( multi_token, { get_self(), "active"_n });
     transfer.send(get_self(), sender, quantity, "fund");
+
+    // sync (MIGRATION ONLY)
+    BancorConverter::synctable_action synctable( get_self(), { get_self(), "active"_n });
+    synctable.send( converter );
 }
 
 [[eosio::action]]
@@ -135,6 +139,10 @@ void BancorConverter::liquidate( const name sender, const asset quantity) {
     // remove smart tokens from circulation
     Token::retire_action retire( multi_token, { get_self(), "active"_n });
     retire.send(quantity, "liquidation");
+
+    // sync (MIGRATION ONLY)
+    BancorConverter::synctable_action synctable( get_self(), { get_self(), "active"_n });
+    synctable.send( converter );
 }
 
 double BancorConverter::calculate_liquidate_return( const double liquidation_amount, const double supply, const double reserve_balance, const double total_weight) {


### PR DESCRIPTION
Once legacy `converters` & `reserves` tables are deleted, upgrade code to sync `converters.v2` => `converters`

Can manually execute sync all tables using `synctables` ACTION:

```bash
cleos push action bancorcnvrtr synctables '[["EOSBNT"]]' -p bancorcnvrtr
```

Also any ongoing table changes will trigger `syntable` for that particular currency, which results in having both tables synced all the time after initial `synctables`.